### PR TITLE
Fixed BlipInput and BlipSelect duplication bug.

### DIFF
--- a/sample/src/components/BlipInput/BlipInputComponent.js
+++ b/sample/src/components/BlipInput/BlipInputComponent.js
@@ -1,13 +1,13 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { BlipInput } from 'blip-toolkit'
 
-export const BlipInputReact = (props) => {
+export const BlipInputComponent = (props) => {
   const wrapper = useRef(undefined)
-  const instance = new BlipInput(props)
+  const [instance] = useState(new BlipInput(props))
 
   useEffect(() => {
-    if(instance){
+    if (instance) {
       const element = instance.render(props)
       wrapper.current.appendChild(element)
     }
@@ -16,6 +16,6 @@ export const BlipInputReact = (props) => {
   return <div ref={wrapper} className={props.className} />
 }
 
-BlipInputReact.propTypes={
+BlipInputComponent.propTypes = {
   className: PropTypes.string,
 }

--- a/sample/src/components/BlipSelect/BlipSelectComponent.js
+++ b/sample/src/components/BlipSelect/BlipSelectComponent.js
@@ -4,7 +4,7 @@ import { BlipSelect } from 'blip-toolkit'
 
 const BlipSelectComponent = (props) => {
   const wrapper = useRef(undefined)
-  const instance = new BlipSelect(props)
+  const [instance] = useState(new BlipSelect(props))
 
   useEffect(() => {
     if (instance) {


### PR DESCRIPTION
**Bug description**

When creating an useState for BlipInput or BlipSelect, the onInputChange will set the state and store the new value for the state, making the whole page re-render as is the React propose.

When this happens, the BlipInput instance is resetted, making the useEffect append a new child, duplicating the input for every single change of state.

**Bug Fix**

Store the instance of the new BlipInput from the toolkit inside a useState variable. That will make the instance unique and not affected by state changes.

---------------------

Both BlipInput and BlipSelect are now fixed and should not make the error again.